### PR TITLE
Fix Google Places retry crash and clean up lint issues

### DIFF
--- a/services/google_places_service.py
+++ b/services/google_places_service.py
@@ -1,6 +1,7 @@
 import googlemaps
 from config import Config
 import logging
+import time
 from .place_ranker import PlaceRanker
 from .place_filter import PlaceFilter
 from .place_search_config import PlaceSearchConfig

--- a/services/rate_limiter.py
+++ b/services/rate_limiter.py
@@ -1,7 +1,6 @@
-from config import Config
 import logging
 import time
-from collections import defaultdict, deque
+from collections import deque
 from threading import Lock
 
 

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,6 +1,4 @@
 import streamlit as st
-import pandas as pd
-from datetime import datetime
 
 def display_places_data(places_data, title):
     """Display places data in a formatted way"""

--- a/utils/pdf_export_helper.py
+++ b/utils/pdf_export_helper.py
@@ -1,14 +1,10 @@
-import streamlit as st
-import time
 from reportlab.lib import colors
-from reportlab.lib.pagesizes import letter, A4
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle, PageBreak, KeepTogether
+from reportlab.lib.pagesizes import A4
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle, PageBreak
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from reportlab.lib.units import inch, cm
-from reportlab.lib.enums import TA_CENTER, TA_LEFT, TA_JUSTIFY, TA_RIGHT
-from reportlab.platypus.tableofcontents import TableOfContents
-from reportlab.graphics.shapes import Drawing, Rect, Line
-from reportlab.graphics import renderPDF
+from reportlab.lib.units import inch
+from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
+from reportlab.graphics.shapes import Drawing, Line
 import io
 from datetime import datetime
 import re
@@ -65,17 +61,6 @@ def create_pdf_report(search_results, conversation_history=None):
         textColor=colors.HexColor('#2D3748'),
         fontName='Helvetica-Bold',
         borderPadding=5
-    )
-    
-    section_header_style = ParagraphStyle(
-        'SectionHeader',
-        parent=styles['Heading3'],
-        fontSize=16,
-        spaceAfter=12,
-        spaceBefore=15,
-        textColor=colors.HexColor('#2B6CB0'),
-        fontName='Helvetica-Bold',
-        leftIndent=0
     )
     
     place_title_style = ParagraphStyle(
@@ -505,7 +490,7 @@ def format_conversation_history(messages, user_style, ai_style, meta_style):
             user_text = f"<b>👤 You asked:</b><br/><br/>{clean_content}"
             try:
                 elements.append(Paragraph(user_text, user_style))
-            except Exception as e:
+            except Exception:
                 # Fallback to plain text if formatting fails
                 plain_text = f"You asked: {content[:500]}..."
                 elements.append(Paragraph(plain_text, user_style))
@@ -519,7 +504,7 @@ def format_conversation_history(messages, user_style, ai_style, meta_style):
             ai_text = f"<b>🤖 Travel Buddy replied:</b><br/><br/>{clean_content}"
             try:
                 elements.append(Paragraph(ai_text, ai_style))
-            except Exception as e:
+            except Exception:
                 # Fallback to plain text if formatting fails
                 plain_text = f"Travel Buddy replied: {content[:500]}..."
                 elements.append(Paragraph(plain_text, ai_style))


### PR DESCRIPTION
### Motivation
- Prevent runtime `NameError` in Google Places retry/backoff and batch delays by ensuring `time` is imported. 
- Resolve multiple linter errors reported by `ruff` due to unused imports and variables to improve code quality. 
- Keep runtime behavior unchanged while making the codebase cleaner and more maintainable.

### Description
- Added `import time` to `services/google_places_service.py` to fix sleeps used in retry/backoff and batching logic. 
- Removed unused imports from `services/rate_limiter.py` and `utils/helpers.py` to satisfy lint rules. 
- Simplified `utils/pdf_export_helper.py` by removing unused imports and an unused `section_header_style`, and changed two `except Exception as e` handlers to `except Exception` where the exception value was unused. 
- No functional behavior changes beyond preventing the crash in retry paths and cleaning up lint warnings.

### Testing
- Ran `ruff check .` and the linter reported no remaining issues after fixes. 
- Ran `python -m compileall -q .` and compilation succeeded. 
- Ran `pytest -q` but no tests exist in the repository so none were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c64dec665c8322bedf2193e98f82a8)